### PR TITLE
FAQ を一番下にする

### DIFF
--- a/_includes/navi.html
+++ b/_includes/navi.html
@@ -17,8 +17,8 @@
           <li><a href="#about"><i class="service-icon fa fa-info"></i>&nbsp;NSEGとは</a></li>
           <li><a href="#howto"><i class="service-icon fa fa-user"></i>&nbsp;参加方法</a></li>
           <li><a href="#regular"><i class="service-icon fa fa-laptop"></i>&nbsp;定期勉強会</a></li>
-          <li><a href="http://github.com/nseg-jp/w/wiki/FAQ" target="_blank"><i class="service-icon fa fa-question"></i>&nbsp;FAQ</a></li>
           <li><a href="#projects"><i class="service-icon fa fa-legal"></i>&nbsp;公式プロジェクト</a></li>
+          <li><a href="http://github.com/nseg-jp/w/wiki/FAQ" target="_blank"><i class="service-icon fa fa-question"></i>&nbsp;FAQ</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
ナビのアイテムが、
- 定期勉強会
- FAQ
- 公式プロジェクト

の順で、(おそらく作業上ずれてしまったものだと思うので、)
- 定期勉強会
- 公式プロジェクト
- FAQ

にします。
