### PR TITLE
公式プロジェクトに BitKids を追加して、表記を調整。

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,4 +36,6 @@ NSEG として開催した勉強会は、概要を [Wiki](http://github.com/nseg
 ## 公式プロジェクト
 {: #projects}
  
-公式の [GitHub Organization](http://github.com/nseg-jp/) があります。NSEG 発のなにがしかの成果物が発表されるかもしれません？？
+* [BitKids](http://bitkids.github.io/) 子供向けプログラミングQ&Aサービス
+
+その他にも NSEG の [GitHub Organization](http://github.com/nseg-jp/) にはこれから形になるプロジェクトが控えているかもしれません？？


### PR DESCRIPTION
「公式プロジェクト」の項目に BitKids を明記しました。

[Wiki](https://github.com/nseg-jp/w/wiki) の内容から動的に持ってこようかとも思ったのですが、ここは更新頻度は低そうなので、無駄に複雑にするよりはこれでいいかなというところで。

[長野Debian勉強会](https://github.com/nseg-jp/naganodebian) は、迷いつつ入れませんでしたが、必要なら後で各々入れてもらう感じでお願いしたいと思います。

マージしていいでしょうか。
