### PR TITLE
画像リストに更新があったときの差分がわかりにくいのでJSON#generateをJSON#pretty_generateにした

### DIFF
--- a/assets/js/vegas-imgs.js
+++ b/assets/js/vegas-imgs.js
@@ -1,1 +1,402 @@
-var vegas_imgs = [{"src":"http://farm1.static.flickr.com/650/23393270425_319d53514d_n.jpg","fade":2000},{"src":"http://farm1.static.flickr.com/660/23025299789_39175f72fd_n.jpg","fade":2000},{"src":"http://farm1.static.flickr.com/671/23367110866_cf1948e750_n.jpg","fade":2000},{"src":"http://farm1.static.flickr.com/689/23777871711_8bf8d9a97e_n.jpg","fade":2000},{"src":"http://farm1.static.flickr.com/724/23834267126_107f4e817a_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2898/14433316664_b2e7d54e36_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2903/14471177775_2e015316c7_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2907/14448084756_478760b107_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2921/14247856860_58820cb0b1_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2923/14434444125_8636d65b51_n.jpg","fade":2000},{"src":"http://farm3.static.flickr.com/2931/14248023867_974e08ea96_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3852/14448092146_d2e9a14675_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3857/14448097386_6b8a2849f7_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3873/14431102911_7619695b99_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3876/14249692708_b93a840551_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3887/14247850340_d853137b47_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3904/14448094756_f8689c02d2_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3925/14433133562_914acc0226_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3932/15620796561_7e9f624fcd_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3934/15003296033_c2ba65e3a1_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3936/15002700374_ca49fde2f9_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3937/15624308582_ca5217d9c6_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3940/15599776516_262df18809_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3941/15002701534_4dd61248e2_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3943/15437462457_0a06411ddc_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3944/15002702124_e42acb0ce3_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3946/15436828869_ac212cf87e_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3947/15436828149_55296d4fda_n.jpg","fade":2000},{"src":"http://farm4.static.flickr.com/3951/15624310112_7c0c3e95f4_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5036/7431275534_f5fc35cb6f_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5072/7440225614_6f2ccb233d_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5079/7440222072_acecab15f7_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5113/7431280314_93571d9236_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5151/7431246452_cbc7c19f85_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5191/7440220914_4beefb459d_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5194/7440195648_f2dbd774f3_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5233/14471185315_c732433a03_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5316/7431259382_e0a0780100_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5330/7440197492_b6f496696c_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5338/7440202736_bbc94ea6de_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5346/7440226808_14bc68df38_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5447/7440207012_4d815ccfa4_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5452/7440219790_96e8582fec_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5462/7440211598_5dd0bb0db6_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5463/7440210464_d2075e42b6_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5464/7440201570_ae0d4097fd_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5483/14247793269_88361e3a85_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5556/14467823341_abac8c8bf4_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5562/14737025678_0a3a1995be_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5571/14736980659_5bf44c7361_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5590/14923296622_5057ec9a01_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5594/14737068337_72304eea7f_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5597/15003297783_4be96be01a_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5598/15002699744_9f122bedcf_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5598/15599773436_9ff5fceda2_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5609/15002701024_6e5fd3bf87_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5609/15623462515_f41f1657f4_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5613/15436827129_7276e1809e_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5613/15437463787_737d40b1d5_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5614/15437465507_835fb082e6_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5614/15623461005_37eff1c656_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5651/23777870671_926f00e49f_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5669/23565755290_2fd557cc53_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5757/23492451319_c5cf143d7e_n.jpg","fade":2000},{"src":"http://farm6.static.flickr.com/5768/23777872321_af64c8ed39_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7112/7440203818_435503b662_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7115/7440214214_3e10210c6d_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7118/7440200764_7b23e5c513_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7118/7440204602_0c9c8174d0_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7119/7431287080_4f7a187542_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7123/7440198448_5f491488b9_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7130/7440217184_1984286c9e_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7139/7431254930_e9c00ddbbd_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7139/7440209158_bd46290872_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7140/7440205636_29cf1fbca2_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7247/7440223436_9f06815c59_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7251/7440218638_1483d3f9ba_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7254/7440193674_bd64024420_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7268/7431266542_79c4dda6f8_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7269/7431270692_f119221f74_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7271/7431249946_15cda5e5ab_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7276/7440215958_25f919eae2_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7277/7440199798_bf13f2a54a_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7322/16425009851_96ce9c099f_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7334/16239366250_072c02c261_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7365/16239123568_78fa0e9d98_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7374/16239124078_105f55ee43_n.jpg","fade":2000},{"src":"http://farm8.static.flickr.com/7703/17276324872_00369beb45_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8007/7431263034_8c3ac610f8_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8008/7431238648_c523733776_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8008/7440196614_1ef84136ab_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8013/7440207938_4f4802c504_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8020/7440228030_7476faea8f_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8028/7440194580_e8545428c4_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8143/7440212934_c10b3e7704_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8155/7431242584_13cb7981f0_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8165/7440229200_787ba5f7c7_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8721/17277622421_e5ec512741_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8735/16655674624_2da2268d94_n.jpg","fade":2000},{"src":"http://farm9.static.flickr.com/8768/16657888423_86bf1bfb52_n.jpg","fade":2000}]
+var vegas_imgs = [
+  {
+    "src": "http://farm1.static.flickr.com/650/23393270425_319d53514d_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm1.static.flickr.com/660/23025299789_39175f72fd_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm1.static.flickr.com/671/23367110866_cf1948e750_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm1.static.flickr.com/689/23777871711_8bf8d9a97e_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm1.static.flickr.com/724/23834267126_107f4e817a_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2898/14433316664_b2e7d54e36_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2903/14471177775_2e015316c7_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2907/14448084756_478760b107_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2921/14247856860_58820cb0b1_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2923/14434444125_8636d65b51_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm3.static.flickr.com/2931/14248023867_974e08ea96_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3852/14448092146_d2e9a14675_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3857/14448097386_6b8a2849f7_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3873/14431102911_7619695b99_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3876/14249692708_b93a840551_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3887/14247850340_d853137b47_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3904/14448094756_f8689c02d2_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3925/14433133562_914acc0226_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3932/15620796561_7e9f624fcd_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3934/15003296033_c2ba65e3a1_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3936/15002700374_ca49fde2f9_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3937/15624308582_ca5217d9c6_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3940/15599776516_262df18809_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3941/15002701534_4dd61248e2_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3943/15437462457_0a06411ddc_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3944/15002702124_e42acb0ce3_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3946/15436828869_ac212cf87e_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3947/15436828149_55296d4fda_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm4.static.flickr.com/3951/15624310112_7c0c3e95f4_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5036/7431275534_f5fc35cb6f_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5072/7440225614_6f2ccb233d_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5079/7440222072_acecab15f7_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5113/7431280314_93571d9236_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5151/7431246452_cbc7c19f85_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5191/7440220914_4beefb459d_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5194/7440195648_f2dbd774f3_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5233/14471185315_c732433a03_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5316/7431259382_e0a0780100_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5330/7440197492_b6f496696c_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5338/7440202736_bbc94ea6de_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5346/7440226808_14bc68df38_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5447/7440207012_4d815ccfa4_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5452/7440219790_96e8582fec_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5462/7440211598_5dd0bb0db6_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5463/7440210464_d2075e42b6_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5464/7440201570_ae0d4097fd_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5483/14247793269_88361e3a85_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5556/14467823341_abac8c8bf4_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5562/14737025678_0a3a1995be_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5571/14736980659_5bf44c7361_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5590/14923296622_5057ec9a01_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5594/14737068337_72304eea7f_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5597/15003297783_4be96be01a_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5598/15002699744_9f122bedcf_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5598/15599773436_9ff5fceda2_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5609/15002701024_6e5fd3bf87_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5609/15623462515_f41f1657f4_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5613/15436827129_7276e1809e_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5613/15437463787_737d40b1d5_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5614/15437465507_835fb082e6_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5614/15623461005_37eff1c656_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5651/23777870671_926f00e49f_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5669/23565755290_2fd557cc53_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5757/23492451319_c5cf143d7e_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm6.static.flickr.com/5768/23777872321_af64c8ed39_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7112/7440203818_435503b662_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7115/7440214214_3e10210c6d_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7118/7440200764_7b23e5c513_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7118/7440204602_0c9c8174d0_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7119/7431287080_4f7a187542_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7123/7440198448_5f491488b9_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7130/7440217184_1984286c9e_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7139/7431254930_e9c00ddbbd_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7139/7440209158_bd46290872_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7140/7440205636_29cf1fbca2_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7247/7440223436_9f06815c59_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7251/7440218638_1483d3f9ba_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7254/7440193674_bd64024420_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7268/7431266542_79c4dda6f8_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7269/7431270692_f119221f74_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7271/7431249946_15cda5e5ab_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7276/7440215958_25f919eae2_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7277/7440199798_bf13f2a54a_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7322/16425009851_96ce9c099f_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7334/16239366250_072c02c261_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7365/16239123568_78fa0e9d98_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7374/16239124078_105f55ee43_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm8.static.flickr.com/7703/17276324872_00369beb45_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8007/7431263034_8c3ac610f8_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8008/7431238648_c523733776_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8008/7440196614_1ef84136ab_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8013/7440207938_4f4802c504_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8020/7440228030_7476faea8f_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8028/7440194580_e8545428c4_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8143/7440212934_c10b3e7704_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8155/7431242584_13cb7981f0_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8165/7440229200_787ba5f7c7_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8721/17277622421_e5ec512741_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8735/16655674624_2da2268d94_n.jpg",
+    "fade": 2000
+  },
+  {
+    "src": "http://farm9.static.flickr.com/8768/16657888423_86bf1bfb52_n.jpg",
+    "fade": 2000
+  }
+]

--- a/batch/genimglist.rb
+++ b/batch/genimglist.rb
@@ -52,7 +52,7 @@ class NSEGImgListGenerator
     imgs.sort.each do |i|
       buff << { :src => i, :fade => 2000  } 
     end
-    return JSON.generate(buff)
+    return JSON.pretty_generate(buff)
   end
 
 end


### PR DESCRIPTION
@tmtms とみたさんに運営してもらっている、Flickr からひっぱってきた写真リストが更新されたらコミットしなおす仕組みですが、現状どういう差分が発生したのかわかりにくいので、JSON#generate を JSON#pretty_generate にして human readable な JSON を吐き出すようにしてはどうだろう？と思いました。
でもこれでかえってとみたさんの更新の仕組みのほうに影響がでるとよくない気がするのですけど、いかがでしょう？